### PR TITLE
Fix typos in code comments

### DIFF
--- a/src/braille/internal/braillecode.cpp
+++ b/src/braille/internal/braillecode.cpp
@@ -450,7 +450,7 @@ braille_code Braille_FigureExtension = braille_code("FigureExtension", "1");
 braille_code Braille_FirstValueRange = braille_code("FirstValueRange", "45-126-2");
 //#16th-128th notes range
 braille_code Braille_SecondValueRange = braille_code("SecondValueRange", "6-126-2");
-//#256th notes and and further range
+//#256th notes and further range
 braille_code Braille_ThirdValueRange = braille_code("ThirdValueRange", "56-126-2");
 
 braille_code* Braille_ValueRanges[] = { &Braille_FirstValueRange, &Braille_SecondValueRange, &Braille_ThirdValueRange };

--- a/src/braille/internal/braillecode.h
+++ b/src/braille/internal/braillecode.h
@@ -350,7 +350,7 @@ extern braille_code Braille_FigureExtension;
 extern braille_code Braille_FirstValueRange;
 //#16th-128th notes range
 extern braille_code Braille_SecondValueRange;
-//#256th notes and and further range
+//#256th notes and further range
 extern braille_code Braille_ThirdValueRange;
 
 extern braille_code* Braille_ValueRanges[];

--- a/src/engraving/api/v1/instrument.h
+++ b/src/engraving/api/v1/instrument.h
@@ -275,11 +275,11 @@ public:
     /// \param pitch Pitch to find variants for.
     Q_INVOKABLE QVariantList variants(int pitch);
 
-    /// The row the given pitch appears in in the percussion panel.
+    /// The row the given pitch appears in the percussion panel.
     /// \param pitch The pitch of the note to find the row for.
     Q_INVOKABLE int panelRow(int pitch) { return drumset()->panelRow(pitch); }
 
-    /// The column the given pitch appears in in the percussion panel.
+    /// The column the given pitch appears in the percussion panel.
     /// \param pitch The pitch of the note to find the column for.
     Q_INVOKABLE int panelColumn(int pitch) { return drumset()->panelColumn(pitch); }
 

--- a/src/engraving/dom/chord.cpp
+++ b/src/engraving/dom/chord.cpp
@@ -1855,7 +1855,7 @@ void Chord::updateArticulations(const std::set<SymId>& newArticulationIds, Artic
 
     // newArtics now contains the articulations in the correct direction
     if (updateMode == ArticulationsUpdateMode::Remove) {
-        // remove articulations from _articulations that are found in in newArtics
+        // remove articulations from _articulations that are found in newArtics
         for (const SymId& id : newArtics) {
             switch (id) {
             case SymId::articAccentAbove:

--- a/src/engraving/rendering/score/boxlayout.cpp
+++ b/src/engraving/rendering/score/boxlayout.cpp
@@ -228,7 +228,7 @@ void BoxLayout::layoutFBox(const FBox* item, FBox::LayoutData* ldata, const Layo
 
         TLayout::layoutItem(fretDiagram, const_cast<LayoutContext&>(ctx));
 
-        //! reset the skip wich was added above
+        //! reset the skip which was added above
         fretDiagram->mutldata()->setIsSkipDraw(false);
         harmony->mutldata()->setIsSkipDraw(false);
 

--- a/src/engraving/types/constants.h
+++ b/src/engraving/types/constants.h
@@ -37,7 +37,7 @@ struct Constants
 //    1.5   save xoff/yoff in mm instead of pixel
 //    1.6   save harmony base/root as tpc value
 //    1.7   invert semantic of page fill limit
-//    1.8   slur id, slur anchor in in Note
+//    1.8   slur id, slur anchor in Note
 //    1.9   image size stored in mm instead of pixel (Versions 0.9.2 -0.9.3)
 //    1.10  TextLine properties changed (Version 0.9.4)
 //    1.11  Instrument name in part saved as TextC (Version 0.9.5)

--- a/src/importexport/mei/internal/meiconverter.cpp
+++ b/src/importexport/mei/internal/meiconverter.cpp
@@ -3468,7 +3468,7 @@ void Convert::textToMEI(textWithSmufl& textBlocks, const String& text)
         }
         // SMuFL
         else {
-            // Changing to smufl, add the current plain text block if something in in
+            // Changing to smufl, add the current plain text block if something is in it
             if (!isSmufl && textBlock.size() > 0) {
                 textBlocks.push_back(std::make_pair(false, textBlock));
                 textBlock.clear();

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -6574,7 +6574,7 @@ static void segmentHarmonies(ExportMusicXml* exp, track_idx_t track, Segment* se
  * and fretboard diagrams.
  *
  * In MuseScore, the Harmony element is now a child of FretboardDiagram BUT in previous versions,
- * both elements were independant siblings so we have to handle both cases.
+ * both elements were independent siblings so we have to handle both cases.
  * In MusicXML, fretboard diagram is always contained in a harmony element.
  *
  * In MuseScore, Harmony elements are not always linked to notes, and each Harmony will be contained

--- a/src/notationscene/qml/MuseScore/NotationScene/percussionpanel/PercussionPanelPadContent.qml
+++ b/src/notationscene/qml/MuseScore/NotationScene/percussionpanel/PercussionPanelPadContent.qml
@@ -141,7 +141,7 @@ Column {
             anchors.fill: parent
 
             engravingItem: Boolean(root.padModel) ? root.padModel.notationPreviewItem : null
-            spatium: 6.25 // Value approximated visually (needs to accomodate "extreme ledger line" situations)
+            spatium: 6.25 // Value approximated visually (needs to accommodate "extreme ledger line" situations)
 
             opacity: 0.9
         }


### PR DESCRIPTION
I have corrected various typos in code comments and QML string literals across the codebase. These include redundant word repetitions (like "and and" or "in in") and common misspellings (like "independant", "accomodate", and "wich"). These changes are safe as they only affect documentation and display strings without altering application logic.

---
*PR created automatically by Jules for task [14007416763335504340](https://jules.google.com/task/14007416763335504340) started by @rettinghaus*