### PR TITLE
Decouple non-solid slur/tie layout from thickness parameters

### DIFF
--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -2683,7 +2683,10 @@ void SlurTieLayout::computeBezier(TieSegment* tieSeg, PointF shoulderOffset)
 
     computeMidThickness(tieSeg, tieLengthInSp);
 
-    PointF tieThickness(0.0, tieSeg->ldata()->midThickness());
+    PointF tieThickness(0.0, 0.0);
+    if (tieSeg->tie()->styleType() == SlurStyleType::Solid) {
+        tieThickness.setY(tieSeg->ldata()->midThickness());
+    }
 
     const PointF bezier1Offset = t.map(tieSeg->ups(Grip::BEZIER1).off);
     const PointF bezier2Offset = t.map(tieSeg->ups(Grip::BEZIER2).off);
@@ -2843,7 +2846,11 @@ void SlurTieLayout::computeBezier(SlurSegment* slurSeg, PointF shoulderOffset)
 
     // Set slur thickness
     computeMidThickness(slurSeg, p2.x() / slurSeg->spatium());
-    PointF thick(0.0, slurSeg->ldata()->midThickness());
+
+    PointF thick(0.0, 0.0);
+    if (slurSeg->slur()->styleType() == SlurStyleType::Solid) {
+        thick.setY(slurSeg->ldata()->midThickness());
+    }
 
     // Set path
     PainterPath path = PainterPath();
@@ -3173,10 +3180,18 @@ void SlurTieLayout::layoutSegment(SlurSegment* item, const PointF& p1, const Poi
 
 void SlurTieLayout::computeMidThickness(SlurTieSegment* slurTieSeg, double slurTieLengthInSp)
 {
-    const double endWidth = slurTieSeg->endWidth();
-    const double midWidth = slurTieSeg->midWidth();
     Staff* staff = slurTieSeg->score() ? slurTieSeg->score()->staff(slurTieSeg->vStaffIdx()) : nullptr;
     const double mag = staff ? staff->staffMag(slurTieSeg->slurTie()->tick()) : 1.0;
+    const double scalingFactor = slurTieSeg->slurTie()->scalingFactor();
+
+    if (slurTieSeg->slurTie()->styleType() != SlurStyleType::Solid) {
+        double finalThickness = 0.5 * slurTieSeg->dottedWidth() * mag * scalingFactor;
+        slurTieSeg->mutldata()->midThickness.set_value(finalThickness);
+        return;
+    }
+
+    const double endWidth = slurTieSeg->endWidth();
+    const double midWidth = slurTieSeg->midWidth();
     const double minTieLength = mag * slurTieSeg->style().styleS(Sid::minTieLength).val();
     const double shortTieLimit = mag * 4.0;
     const double minTieThickness = mag * (0.15 * slurTieSeg->spatium() - endWidth);
@@ -3193,8 +3208,6 @@ void SlurTieLayout::computeMidThickness(SlurTieSegment* slurTieSeg, double slurT
         const double C = shortTieLimit * minTieThickness - minTieLength * normalThickness;
         finalThickness = A * (B * slurTieLengthInSp + C);
     }
-
-    double scalingFactor = slurTieSeg->slurTie()->scalingFactor();
 
     finalThickness = std::min(finalThickness, normalThickness * scalingFactor);
 
@@ -3216,7 +3229,10 @@ void SlurTieLayout::fillShape(SlurTieSegment* slurTieSeg, double slurTieLengthIn
         double percent = pow(sin(0.5 * M_PI * (double(i) / double(nbShapes))), 2);
         const PointF point = b.pointAtPercent(percent);
         RectF re = RectF(startPoint, point).normalized();
-        double approxThicknessAtPercent = (1 - 2 * std::abs(0.5 - percent)) * midThickness;
+        double approxThicknessAtPercent = midThickness;
+        if (slurTieSeg->slurTie()->styleType() == SlurStyleType::Solid) {
+            approxThicknessAtPercent *= (1 - 2 * std::abs(0.5 - percent));
+        }
         if (re.height() < approxThicknessAtPercent) {
             double adjust = (approxThicknessAtPercent - re.height()) * .5;
             re.adjust(0.0, -adjust, 0.0, adjust);

--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -2400,9 +2400,19 @@ void SlurTieLayout::adjustY(TieSegment* tieSegment)
     RectF tieSegmentBBox = tieSegment->ldata()->bbox();
     double tieLength = tieSegmentBBox.width();
     double tieHeight = tieSegmentBBox.height();
-    double midThickness = tieSegment->ldata()->midThickness() * 2;
-    double yOuterApogee = up ? tieSegmentBBox.top() : tieSegmentBBox.bottom();
-    double yInnerApogee = yOuterApogee - midThickness * upSign;
+    double bodyWidth = tieSegment->ldata()->midThickness() * 2;
+    double yPeak = up ? tieSegmentBBox.top() : tieSegmentBBox.bottom();
+    double yOuterApogee;
+    double yInnerApogee;
+
+    if (tieSegment->slurTie()->styleType() == SlurStyleType::Solid) {
+        yOuterApogee = yPeak;
+        yInnerApogee = yOuterApogee - bodyWidth * upSign;
+    } else {
+        yOuterApogee = yPeak + 0.5 * bodyWidth * upSign;
+        yInnerApogee = yPeak - 0.5 * bodyWidth * upSign;
+    }
+
     double yMidApogee = 0.5 * (yOuterApogee + yInnerApogee);
 
     int closestLineToArc = round(yMidApogee / staffLineDist);
@@ -2506,9 +2516,21 @@ void SlurTieLayout::resolveVerticalTieCollisions(const std::vector<TieSegment*>&
         bool up = thisTie->tie()->up();
         int upSign = up ? -1 : 1;
 
+        double thisTieBodyWidth = thisTie->ldata()->midThickness() * 2;
         double thisTieOuterY = up ? thisTie->ldata()->bbox().top() : thisTie->ldata()->bbox().bottom();
-        double nextTieInnerY = (up ? nextTie->ldata()->bbox().top() : nextTie->ldata()->bbox().bottom())
-                               - upSign * 2 * nextTie->ldata()->midThickness();
+        if (thisTie->slurTie()->styleType() != SlurStyleType::Solid) {
+            thisTieOuterY += 0.5 * thisTieBodyWidth * upSign;
+        }
+
+        double nextTieBodyWidth = nextTie->ldata()->midThickness() * 2;
+        double nextTiePeakY = up ? nextTie->ldata()->bbox().top() : nextTie->ldata()->bbox().bottom();
+        double nextTieInnerY;
+        if (nextTie->slurTie()->styleType() == SlurStyleType::Solid) {
+            nextTieInnerY = nextTiePeakY - nextTieBodyWidth * upSign;
+        } else {
+            nextTieInnerY = nextTiePeakY - 0.5 * nextTieBodyWidth * upSign;
+        }
+
         double clearanceMargin = 0.15 * spatium;
         bool collision = upSign * (nextTieInnerY - thisTieOuterY) < clearanceMargin;
         if (!collision) {

--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -3202,38 +3202,38 @@ void SlurTieLayout::layoutSegment(SlurSegment* item, const PointF& p1, const Poi
 
 void SlurTieLayout::computeMidThickness(SlurTieSegment* slurTieSeg, double slurTieLengthInSp)
 {
+    const double endWidth = slurTieSeg->endWidth();
+    const double midWidth = slurTieSeg->midWidth();
     Staff* staff = slurTieSeg->score() ? slurTieSeg->score()->staff(slurTieSeg->vStaffIdx()) : nullptr;
     const double mag = staff ? staff->staffMag(slurTieSeg->slurTie()->tick()) : 1.0;
+    const double minTieLength = mag * slurTieSeg->style().styleS(Sid::minTieLength).val();
+    const double shortTieLimit = mag * 4.0;
     const double scalingFactor = slurTieSeg->slurTie()->scalingFactor();
 
     if (slurTieSeg->slurTie()->styleType() != SlurStyleType::Solid) {
-        double finalThickness = 0.5 * slurTieSeg->dottedWidth() * mag * scalingFactor;
-        slurTieSeg->mutldata()->midThickness.set_value(finalThickness);
+        double endThickness = 0.5 * slurTieSeg->dottedWidth() * mag * scalingFactor;
+        slurTieSeg->mutldata()->midThickness.set_value(endThickness);
         return;
     }
 
-    const double endWidth = slurTieSeg->endWidth();
-    const double midWidth = slurTieSeg->midWidth();
-    const double minTieLength = mag * slurTieSeg->style().styleS(Sid::minTieLength).val();
-    const double shortTieLimit = mag * 4.0;
     const double minTieThickness = mag * (0.15 * slurTieSeg->spatium() - endWidth);
     const double normalThickness = mag * (midWidth - endWidth);
 
     bool invalid = muse::RealIsEqualOrMore(minTieLength, shortTieLimit);
 
-    double finalThickness;
+    double endThickness;
     if (slurTieLengthInSp > shortTieLimit || invalid) {
-        finalThickness = normalThickness;
+        endThickness = normalThickness;
     } else {
         const double A = 1 / (shortTieLimit - minTieLength);
         const double B = normalThickness - minTieThickness;
         const double C = shortTieLimit * minTieThickness - minTieLength * normalThickness;
-        finalThickness = A * (B * slurTieLengthInSp + C);
+        endThickness = A * (B * slurTieLengthInSp + C);
     }
 
-    finalThickness = std::min(finalThickness, normalThickness * scalingFactor);
+    endThickness = std::min(endThickness, normalThickness * scalingFactor);
 
-    slurTieSeg->mutldata()->midThickness.set_value(finalThickness);
+    slurTieSeg->mutldata()->midThickness.set_value(endThickness);
 }
 
 void SlurTieLayout::fillShape(SlurTieSegment* slurTieSeg, double slurTieLengthInSp)

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2655,7 +2655,8 @@ void TDraw::draw(const SlurSegment* item, Painter* painter, const PaintOptions& 
     setMask(item, painter);
 
     Pen pen(item->curColor(opt));
-    double mag = (item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0) * item->slurTie()->scalingFactor();
+    double mag = item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0;
+    double magFull = mag * item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with tie.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
@@ -2673,17 +2674,17 @@ void TDraw::draw(const SlurSegment* item, Painter* painter, const PaintOptions& 
         painter->setBrush(BrushStyle::NoBrush);
         pen.setCapStyle(PenCapStyle::RoundCap);           // round dots
         pen.setDashPattern(dotted);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::Dashed:
         painter->setBrush(BrushStyle::NoBrush);
         pen.setDashPattern(dashed);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::WideDashed:
         painter->setBrush(BrushStyle::NoBrush);
         pen.setDashPattern(wideDashed);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::Undefined:
         break;
@@ -3102,7 +3103,9 @@ void TDraw::draw(const TieSegment* item, Painter* painter, const PaintOptions& o
     }
 
     Pen pen(penColor);
-    double mag = (item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0) * item->slurTie()->scalingFactor();
+    double mag = item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0;
+    double magFull = mag * item->slurTie()->scalingFactor();
+
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with slur.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
     std::vector<double> dashed     = { 3.00, 3.00 };   // Compensating for caps. Qt default PenStyle::DashLine is { 4.0, 2.0 }
@@ -3119,17 +3122,17 @@ void TDraw::draw(const TieSegment* item, Painter* painter, const PaintOptions& o
         painter->setBrush(BrushStyle::NoBrush);
         pen.setCapStyle(PenCapStyle::RoundCap);           // True dots
         pen.setDashPattern(dotted);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::Dashed:
         painter->setBrush(BrushStyle::NoBrush);
         pen.setDashPattern(dashed);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::WideDashed:
         painter->setBrush(BrushStyle::NoBrush);
         pen.setDashPattern(wideDashed);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::Undefined:
         break;

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2655,7 +2655,7 @@ void TDraw::draw(const SlurSegment* item, Painter* painter, const PaintOptions& 
     setMask(item, painter);
 
     Pen pen(item->curColor(opt));
-    double mag = item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0;
+    double mag = (item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0) * item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with tie.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
@@ -3102,7 +3102,7 @@ void TDraw::draw(const TieSegment* item, Painter* painter, const PaintOptions& o
     }
 
     Pen pen(penColor);
-    double mag = item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0;
+    double mag = (item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0) * item->slurTie()->scalingFactor();
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with slur.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
     std::vector<double> dashed     = { 3.00, 3.00 };   // Compensating for caps. Qt default PenStyle::DashLine is { 4.0, 2.0 }

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -2180,7 +2180,8 @@ void SingleDraw::draw(const SlurSegment* item, Painter* painter, const PaintOpti
     TRACE_DRAW_ITEM;
 
     Pen pen(item->curColor(opt));
-    double mag = (item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0) * item->slurTie()->scalingFactor();
+    double mag = item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0;
+    double magFull = mag * item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with tie.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
@@ -2198,17 +2199,17 @@ void SingleDraw::draw(const SlurSegment* item, Painter* painter, const PaintOpti
         painter->setBrush(BrushStyle::NoBrush);
         pen.setCapStyle(PenCapStyle::RoundCap);           // round dots
         pen.setDashPattern(dotted);
-        pen.setWidthF(item->style().styleAbsolute(Sid::slurDottedWidth) * mag);
+        pen.setWidthF(item->style().styleAbsolute(Sid::slurDottedWidth) * magFull);
         break;
     case SlurStyleType::Dashed:
         painter->setBrush(BrushStyle::NoBrush);
         pen.setDashPattern(dashed);
-        pen.setWidthF(item->style().styleAbsolute(Sid::slurDottedWidth) * mag);
+        pen.setWidthF(item->style().styleAbsolute(Sid::slurDottedWidth) * magFull);
         break;
     case SlurStyleType::WideDashed:
         painter->setBrush(BrushStyle::NoBrush);
         pen.setDashPattern(wideDashed);
-        pen.setWidthF(item->style().styleAbsolute(Sid::slurDottedWidth) * mag);
+        pen.setWidthF(item->style().styleAbsolute(Sid::slurDottedWidth) * magFull);
         break;
     case SlurStyleType::Undefined:
         break;
@@ -2374,7 +2375,8 @@ void SingleDraw::draw(const TieSegment* item, Painter* painter, const PaintOptio
     }
 
     Pen pen(item->curColor(opt));
-    double mag = (item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0) * item->slurTie()->scalingFactor();
+    double mag = item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0;
+    double magFull = mag * item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with slur.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
@@ -2392,17 +2394,17 @@ void SingleDraw::draw(const TieSegment* item, Painter* painter, const PaintOptio
         painter->setBrush(BrushStyle::NoBrush);
         pen.setCapStyle(PenCapStyle::RoundCap);           // True dots
         pen.setDashPattern(dotted);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::Dashed:
         painter->setBrush(BrushStyle::NoBrush);
         pen.setDashPattern(dashed);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::WideDashed:
         painter->setBrush(BrushStyle::NoBrush);
         pen.setDashPattern(wideDashed);
-        pen.setWidthF(item->dottedWidth() * mag);
+        pen.setWidthF(item->dottedWidth() * magFull);
         break;
     case SlurStyleType::Undefined:
         break;

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -2180,7 +2180,7 @@ void SingleDraw::draw(const SlurSegment* item, Painter* painter, const PaintOpti
     TRACE_DRAW_ITEM;
 
     Pen pen(item->curColor(opt));
-    double mag = item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0;
+    double mag = (item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0) * item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with tie.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
@@ -2374,7 +2374,7 @@ void SingleDraw::draw(const TieSegment* item, Painter* painter, const PaintOptio
     }
 
     Pen pen(item->curColor(opt));
-    double mag = item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0;
+    double mag = (item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0) * item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with slur.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }


### PR DESCRIPTION
This PR decouples the layout of slurs and ties from their thickness property when set to dotted or dashed styles. 

In the current engine, solid slurs use variable tapering which affects the calculation of outer/inner Bezier curves and collision detection apogees. However, for dotted or dashed lines, the drawing width is fixed. This change ensures that for non-solid styles:
1. The `midThickness` used for layout adjustments and collision detection is fixed based on the `dottedWidth` style property.
2. The Bezier path represents the single centerline of the arc (zero vertical offset).
3. The selection/collision shape (`fillShape`) maintains a constant width along the arc.

Additionally, the rendering code in `TDraw` and `SingleDraw` is updated to include the `scalingFactor()` (for grace notes) in the magnification calculation, ensuring visual consistency with the layout logic.

---
*PR created automatically by Jules for task [15060736795017551986](https://jules.google.com/task/15060736795017551986) started by @rettinghaus*