### PR TITLE
Fix MusicXML import of coda and segno within barline

### DIFF
--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -5766,15 +5766,16 @@ void MusicXmlParserPass2::barline(const String& partId, Measure* measure, const 
         } else if (m_e.name() == "segno") {
             const Color segnoColor = Color::fromString(m_e.asciiAttribute("color").ascii());
             const AsciiStringView segnoSymbol = m_e.asciiAttribute("smufl");
-            Measure* markedMeasure = (loc == "left") ? measure : measure->nextMeasure();
+            Measure* markedMeasure = (loc == u"left") ? measure : measure->nextMeasure();
             if (markedMeasure == nullptr) {
                 m_logger->logError(u"coda or segno marker cannot be placed at the end of the score", &m_e);
+                m_e.skipCurrentElement();
                 continue;
             }
             Marker* m = Factory::createMarker(markedMeasure);
             m->setMarkerType(MarkerType::SEGNO);
             if (!segnoSymbol.empty()) {
-                //m->setSymId(SymNames::symIdByName(segnoSymbol, SymId::noSym));
+                m->setXmlText(u"<sym>" + String::fromAscii(segnoSymbol.ascii()) + u"</sym>");
             }
             if (!segnoLabel.empty()) {
                 m->setLabel(segnoLabel);
@@ -5782,21 +5783,21 @@ void MusicXmlParserPass2::barline(const String& partId, Measure* measure, const 
             if (segnoColor.isValid()) {
                 colorItem(m, segnoColor);
             }
-            m->setTrack(0);
-            markedMeasure->add(m);
+            addElemOffset(m, 0, u"above", markedMeasure, markedMeasure->tick());
             m_e.skipCurrentElement();
         } else if (m_e.name() == "coda") {
             const Color codaColor = Color::fromString(m_e.asciiAttribute("color").ascii());
             const AsciiStringView codaSymbol = m_e.asciiAttribute("smufl");
-            Measure* markedMeasure = (loc == "left") ? measure : measure->nextMeasure();
+            Measure* markedMeasure = (loc == u"left") ? measure : measure->nextMeasure();
             if (markedMeasure == nullptr) {
                 m_logger->logError(u"coda or segno marker cannot be placed at the end of the score", &m_e);
+                m_e.skipCurrentElement();
                 continue;
             }
             Marker* m = Factory::createMarker(markedMeasure);
             m->setMarkerType(MarkerType::CODA);
             if (!codaSymbol.empty()) {
-                //m->setSymId(SymNames::symIdByName(codaSymbol, SymId::noSym));
+                m->setXmlText(u"<sym>" + String::fromAscii(codaSymbol.ascii()) + u"</sym>");
             }
             if (!codaLabel.empty()) {
                 m->setLabel(codaLabel);
@@ -5804,8 +5805,7 @@ void MusicXmlParserPass2::barline(const String& partId, Measure* measure, const 
             if (codaColor.isValid()) {
                 colorItem(m, codaColor);
             }
-            m->setTrack(0);
-            markedMeasure->add(m);
+            addElemOffset(m, 0, u"above", markedMeasure, markedMeasure->tick());
             m_e.skipCurrentElement();
         } else if (m_e.name() == "fermata") {
             const Color fermataColor = Color::fromString(m_e.asciiAttribute("color").ascii());

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -5734,17 +5734,20 @@ Regular barlines should not be added at the start or end of a measure, as that c
 
 void MusicXmlParserPass2::barline(const String& partId, Measure* measure, const Fraction& tick)
 {
-    String loc = m_e.attribute("location");
+    AsciiStringView loc = m_e.asciiAttribute("location");
     if (loc.empty()) {
-        loc = u"right";
+        loc = "right";
     }
     // Place barline in correct place
     Fraction locTick = tick;
-    if (loc == u"left") {
+    if (loc == "left") {
         locTick = measure->tick();
-    } else if (loc == u"right") {
+    } else if (loc == "right") {
         locTick = measure->endTick();
     }
+
+    const String codaLabel = m_e.attribute("coda");
+    const String segnoLabel = m_e.attribute("segno");
 
     String barStyle;
     Color barlineColor;
@@ -5760,12 +5763,50 @@ void MusicXmlParserPass2::barline(const String& partId, Measure* measure, const 
         if (m_e.name() == "bar-style") {
             barlineColor = Color::fromString(m_e.asciiAttribute("color").ascii());
             barStyle = m_e.readText();
-        } else if (m_e.name() == "ending") {
-            endingNumber = m_e.attribute("number");
-            endingType   = m_e.attribute("type");
-            endingColor = Color::fromString(m_e.asciiAttribute("color").ascii());
-            printEnding = m_e.asciiAttribute("print-object") != "no";
-            endingText = m_e.readText();
+        } else if (m_e.name() == "segno") {
+            const Color segnoColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            const AsciiStringView segnoSymbol = m_e.asciiAttribute("smufl");
+            Measure* markedMeasure = (loc == "left") ? measure : measure->nextMeasure();
+            if (markedMeasure == nullptr) {
+                m_logger->logError(u"coda or segno marker cannot be placed at the end of the score", &m_e);
+                continue;
+            }
+            Marker* m = Factory::createMarker(markedMeasure);
+            m->setMarkerType(MarkerType::SEGNO);
+            if (!segnoSymbol.empty()) {
+                //m->setSymId(SymNames::symIdByName(segnoSymbol, SymId::noSym));
+            }
+            if (!segnoLabel.empty()) {
+                m->setLabel(segnoLabel);
+            }
+            if (segnoColor.isValid()) {
+                colorItem(m, segnoColor);
+            }
+            m->setTrack(0);
+            markedMeasure->add(m);
+            m_e.skipCurrentElement();
+        } else if (m_e.name() == "coda") {
+            const Color codaColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            const AsciiStringView codaSymbol = m_e.asciiAttribute("smufl");
+            Measure* markedMeasure = (loc == "left") ? measure : measure->nextMeasure();
+            if (markedMeasure == nullptr) {
+                m_logger->logError(u"coda or segno marker cannot be placed at the end of the score", &m_e);
+                continue;
+            }
+            Marker* m = Factory::createMarker(markedMeasure);
+            m->setMarkerType(MarkerType::CODA);
+            if (!codaSymbol.empty()) {
+                //m->setSymId(SymNames::symIdByName(codaSymbol, SymId::noSym));
+            }
+            if (!codaLabel.empty()) {
+                m->setLabel(codaLabel);
+            }
+            if (codaColor.isValid()) {
+                colorItem(m, codaColor);
+            }
+            m->setTrack(0);
+            markedMeasure->add(m);
+            m_e.skipCurrentElement();
         } else if (m_e.name() == "fermata") {
             const Color fermataColor = Color::fromString(m_e.asciiAttribute("color").ascii());
             const String fermataType = m_e.attribute("type");
@@ -5786,6 +5827,12 @@ void MusicXmlParserPass2::barline(const String& partId, Measure* measure, const 
             // Terminate tempo lines
             const InferredTempoLineStack& lines = getInferredTempoLine();
             terminateInferredLine(std::vector<TextLineBase*>(lines.begin(), lines.end()), locTick, track);
+        } else if (m_e.name() == "ending") {
+            endingNumber = m_e.attribute("number");
+            endingType   = m_e.attribute("type");
+            endingColor = Color::fromString(m_e.asciiAttribute("color").ascii());
+            printEnding = m_e.asciiAttribute("print-object") != "no";
+            endingText = m_e.readText();
         } else if (m_e.name() == "repeat") {
             repeat = m_e.attribute("direction");
             count = m_e.attribute("times");


### PR DESCRIPTION
This change fixes the MusicXML import of coda and segno markers when they are defined within a barline element. Previously, these markers were duplicated for every part and SMuFL symbol support was missing. The fix uses addElemOffset for correct deduplication and system element handling, and implements SMuFL symbol support via setXmlText.

---
*PR created automatically by Jules for task [2872611977029495704](https://jules.google.com/task/2872611977029495704) started by @rettinghaus*