### PR TITLE
Fix MusicXML capo import crash and transposition for TAB staves

### DIFF
--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -287,7 +287,9 @@ static int MusicXmlStepAltOct2Pitch(int step, int alter, int octave)
  Note that n's staff and track have not been set yet
  */
 
-static void xmlSetPitch(Note* n, int step, int alter, double tuning, int octave, const int octaveShift, const Instrument* const instr)
+static void xmlSetPitch(Note* n, const Staff* staff, const Fraction& tick,
+                        int step, int alter, double tuning, int octave,
+                        const int octaveShift, const Instrument* const instr)
 {
     //LOGD("xmlSetPitch(n=%p, step=%d, alter=%d, octave=%d, octaveShift=%d)",
     //       n, step, alter, octave, octaveShift);
@@ -303,18 +305,21 @@ static void xmlSetPitch(Note* n, int step, int alter, double tuning, int octave,
     int pitch = MusicXmlStepAltOct2Pitch(step, alter, octave);
     pitch += intval.chromatic;   // assume not in concert pitch
     pitch += 12 * octaveShift;   // correct for octave shift
-    // ensure sane values
-    pitch = std::clamp(pitch, 0, 127);
 
-    const CapoParams& capo = n->staff()->capo(n->tick());
-    int capoFret = 0;
+    int tpc2 = step2tpc(step, AccidentalVal(alter));
+    int tpc1 = Transpose::transposeTpc(tpc2, intval, true);
 
-    if (capo.active && n->staff()->isTabStaff(Fraction(0, 1))) {
-        capoFret = capo.fretPosition;
+    const CapoParams& capo = staff->capo(tick);
+
+    if (capo.active && staff->isTabStaff(tick)) {
+        if (capo.transposeMode == CapoParams::TransposeMode::TAB_ONLY) {
+            pitch += capo.fretPosition;
+            tpc2 = Transpose::transposeTpc(tpc2, Interval(capo.fretPosition), true);
+        }
     }
 
-    int tpc2 = step2tpc(step + capoFret, AccidentalVal(alter));
-    int tpc1 = Transpose::transposeTpc(tpc2, intval, true);
+    // ensure sane values
+    pitch = std::clamp(pitch, 0, 127);
     n->setPitch(pitch, tpc1, tpc2);
     n->setTuning(tuning);
     //LOGD("  pitch=%d tpc1=%d tpc2=%d", n->pitch(), n->tpc1(), n->tpc2());
@@ -3252,8 +3257,12 @@ void MusicXmlParserPass2::staffDetails(const String& partId, Measure* measure, c
                 Capo* c = Factory::createCapo(m_score->dummy()->segment());
                 CapoParams p = c->params();
                 p.fretPosition = fret;
+                if (m_score->staff(staffIdx)->isTabStaff(tick)) {
+                    p.transposeMode = CapoParams::TransposeMode::TAB_ONLY;
+                }
                 c->setParams(p);
                 addElemOffset(c, staff2track(staffIdx), u"", measure, tick);
+                m_score->staff(staffIdx)->insertCapoParams(tick, p, true);
             } else {
                 m_e.skipCurrentElement();
             }
@@ -6877,7 +6886,9 @@ static void addTremolo(ChordRest* cr, const int tremoloNr, const String& tremolo
 
 // TODO: refactor: optimize parameters
 
-static void setPitch(Note* note, const MusicXmlInstruments& instruments, const String& instrumentId, const MusicXmlNotePitch& mnp,
+static void setPitch(Note* note, const Staff* staff, const Fraction& tick,
+                     const MusicXmlInstruments& instruments,
+                     const String& instrumentId, const MusicXmlNotePitch& mnp,
                      const int octaveShift, const Instrument* const instrument)
 {
     if (mnp.unpitched()) {
@@ -6889,10 +6900,10 @@ static void setPitch(Note* note, const MusicXmlInstruments& instruments, const S
             note->setTpcFromPitch();
         } else {
             //LOGD("disp step %d oct %d", displayStep, displayOctave);
-            xmlSetPitch(note, mnp.displayStep(), 0, 0.0, mnp.displayOctave(), 0, instrument);
+            xmlSetPitch(note, staff, tick, mnp.displayStep(), 0, 0.0, mnp.displayOctave(), 0, instrument);
         }
     } else {
-        xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.tuning(), mnp.octave(), octaveShift, instrument);
+        xmlSetPitch(note, staff, tick, mnp.step(), mnp.alter(), mnp.tuning(), mnp.octave(), octaveShift, instrument);
     }
 }
 
@@ -6939,8 +6950,9 @@ static void setDrumset(Chord* c, MusicXmlParserPass1& pass1, const String& partI
     pass1.setDrumsetDefault(partId, instrumentId, headGroup, line, overruledStemDir);
 }
 
-void MusicXmlParserPass2::xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff, int step, int octave,
-                                             NoteHeadGroup headGroup, DirectionV& stemDir, Instrument* instrument)
+void MusicXmlParserPass2::xmlSetDrumsetPitch(Note* note, const Chord* chord, const Staff* staff,
+                                             int step, int octave, NoteHeadGroup headGroup,
+                                             DirectionV& stemDir, Instrument* instrument)
 {
     Drumset* ds = instrument->drumset();
     // get line
@@ -6980,8 +6992,7 @@ void MusicXmlParserPass2::xmlSetDrumsetPitch(Note* note, const Chord* chord, con
             ds->drum(newPitch) = DrumInstrument();
 
             newPitch = instr.pitch;
-            ds->drum(newPitch) = ds->drum(newPitch) = DrumInstrument(
-                instr.name, headGroup, line, stemDir, static_cast<int>(chord->voice()));
+            ds->drum(newPitch) = DrumInstrument(instr.name, headGroup, line, stemDir, static_cast<int>(chord->voice()));
         }
     }
 
@@ -7299,7 +7310,7 @@ Note* MusicXmlParserPass2::note(const String& partId,
         if (isSingleDrumset && mnp.unpitched() && instrumentId.empty()) {
             xmlSetDrumsetPitch(note, c, st, mnp.displayStep(), mnp.displayOctave(), headGroup, stemDir, instrument);
         } else {
-            setPitch(note, instruments, instrumentId, mnp, octaveShift, instrument);
+            setPitch(note, st, noteStartTime, instruments, instrumentId, mnp, octaveShift, instrument);
         }
         c->add(note);
         cr = c;


### PR DESCRIPTION
This PR fixes a crash during MusicXML import when a capo is present on a TAB staff. The crash was caused by attempting to access the note's staff before it was fully initialized. The fix involves passing the staff and tick explicitly to the pitch calculation functions. Additionally, the PR implements the missing transposition logic for capos on TAB staves, ensuring that both the MIDI pitch and the Tonal Pitch Class (TPC) are correctly adjusted. The staff's internal capo map is also populated during the second import pass to ensure these settings are available for all notes in the score.

---
*PR created automatically by Jules for task [5420413976030512125](https://jules.google.com/task/5420413976030512125) started by @rettinghaus*