### PR TITLE
Fix dashed/dotted slur outlines and hit-boxes

### DIFF
--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -2683,7 +2683,10 @@ void SlurTieLayout::computeBezier(TieSegment* tieSeg, PointF shoulderOffset)
 
     computeMidThickness(tieSeg, tieLengthInSp);
 
-    PointF tieThickness(0.0, tieSeg->ldata()->midThickness());
+    PointF tieThickness(0.0, 0.0);
+    if (tieSeg->tie()->styleType() == SlurStyleType::Solid) {
+        tieThickness.setY(tieSeg->ldata()->midThickness());
+    }
 
     const PointF bezier1Offset = t.map(tieSeg->ups(Grip::BEZIER1).off);
     const PointF bezier2Offset = t.map(tieSeg->ups(Grip::BEZIER2).off);
@@ -2843,7 +2846,11 @@ void SlurTieLayout::computeBezier(SlurSegment* slurSeg, PointF shoulderOffset)
 
     // Set slur thickness
     computeMidThickness(slurSeg, p2.x() / slurSeg->spatium());
-    PointF thick(0.0, slurSeg->ldata()->midThickness());
+
+    PointF thick(0.0, 0.0);
+    if (slurSeg->slur()->styleType() == SlurStyleType::Solid) {
+        thick.setY(slurSeg->ldata()->midThickness());
+    }
 
     // Set path
     PainterPath path = PainterPath();
@@ -3216,7 +3223,10 @@ void SlurTieLayout::fillShape(SlurTieSegment* slurTieSeg, double slurTieLengthIn
         double percent = pow(sin(0.5 * M_PI * (double(i) / double(nbShapes))), 2);
         const PointF point = b.pointAtPercent(percent);
         RectF re = RectF(startPoint, point).normalized();
-        double approxThicknessAtPercent = (1 - 2 * std::abs(0.5 - percent)) * midThickness;
+        double approxThicknessAtPercent = midThickness;
+        if (slurTieSeg->slurTie()->styleType() == SlurStyleType::Solid) {
+            approxThicknessAtPercent *= (1 - 2 * std::abs(0.5 - percent));
+        }
         if (re.height() < approxThicknessAtPercent) {
             double adjust = (approxThicknessAtPercent - re.height()) * .5;
             re.adjust(0.0, -adjust, 0.0, adjust);

--- a/src/engraving/rendering/score/slurtielayout.cpp
+++ b/src/engraving/rendering/score/slurtielayout.cpp
@@ -3180,10 +3180,17 @@ void SlurTieLayout::layoutSegment(SlurSegment* item, const PointF& p1, const Poi
 
 void SlurTieLayout::computeMidThickness(SlurTieSegment* slurTieSeg, double slurTieLengthInSp)
 {
-    const double endWidth = slurTieSeg->endWidth();
-    const double midWidth = slurTieSeg->midWidth();
     Staff* staff = slurTieSeg->score() ? slurTieSeg->score()->staff(slurTieSeg->vStaffIdx()) : nullptr;
     const double mag = staff ? staff->staffMag(slurTieSeg->slurTie()->tick()) : 1.0;
+    const double scalingFactor = slurTieSeg->slurTie()->scalingFactor();
+
+    if (slurTieSeg->slurTie()->styleType() != SlurStyleType::Solid) {
+        slurTieSeg->mutldata()->midThickness.set_value(0.5 * slurTieSeg->dottedWidth() * mag * scalingFactor);
+        return;
+    }
+
+    const double endWidth = slurTieSeg->endWidth();
+    const double midWidth = slurTieSeg->midWidth();
     const double minTieLength = mag * slurTieSeg->style().styleS(Sid::minTieLength).val();
     const double shortTieLimit = mag * 4.0;
     const double minTieThickness = mag * (0.15 * slurTieSeg->spatium() - endWidth);
@@ -3200,8 +3207,6 @@ void SlurTieLayout::computeMidThickness(SlurTieSegment* slurTieSeg, double slurT
         const double C = shortTieLimit * minTieThickness - minTieLength * normalThickness;
         finalThickness = A * (B * slurTieLengthInSp + C);
     }
-
-    double scalingFactor = slurTieSeg->slurTie()->scalingFactor();
 
     finalThickness = std::min(finalThickness, normalThickness * scalingFactor);
 

--- a/src/engraving/rendering/score/tdraw.cpp
+++ b/src/engraving/rendering/score/tdraw.cpp
@@ -2656,6 +2656,7 @@ void TDraw::draw(const SlurSegment* item, Painter* painter, const PaintOptions& 
 
     Pen pen(item->curColor(opt));
     double mag = item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0;
+    mag *= item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with tie.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
@@ -3103,6 +3104,8 @@ void TDraw::draw(const TieSegment* item, Painter* painter, const PaintOptions& o
 
     Pen pen(penColor);
     double mag = item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0;
+    mag *= item->slurTie()->scalingFactor();
+
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with slur.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
     std::vector<double> dashed     = { 3.00, 3.00 };   // Compensating for caps. Qt default PenStyle::DashLine is { 4.0, 2.0 }

--- a/src/engraving/rendering/single/singledraw.cpp
+++ b/src/engraving/rendering/single/singledraw.cpp
@@ -2181,6 +2181,7 @@ void SingleDraw::draw(const SlurSegment* item, Painter* painter, const PaintOpti
 
     Pen pen(item->curColor(opt));
     double mag = item->staff() ? item->staff()->staffMag(item->slur()->tick()) : 1.0;
+    mag *= item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with tie.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }
@@ -2375,6 +2376,7 @@ void SingleDraw::draw(const TieSegment* item, Painter* painter, const PaintOptio
 
     Pen pen(item->curColor(opt));
     double mag = item->staff() ? item->staff()->staffMag(item->tie()->tick()) : 1.0;
+    mag *= item->slurTie()->scalingFactor();
 
     //Replace generic Qt dash patterns with improved equivalents to show true dots (keep in sync with slur.cpp)
     std::vector<double> dotted     = { 0.01, 1.99 };   // tighter than Qt PenStyle::DotLine equivalent - would be { 0.01, 2.99 }


### PR DESCRIPTION
Dashed and dotted slurs previously used the tapered layout thickness calculations intended for solid slurs, resulting in hit-boxes and collision boundaries that did not match their visual constant-thickness shape.

This PR:
1. Updates `SlurTieLayout::computeMidThickness` to use `dottedWidth` for all non-solid styles.
2. Ensures `scalingFactor()` is correctly applied during drawing in both `TDraw` and `SingleDraw` for slurs and ties.
3. Aligns the collision avoidance and click-area logic with the actual drawn appearance of non-solid spanners.

---
*PR created automatically by Jules for task [13133882200412836683](https://jules.google.com/task/13133882200412836683) started by @rettinghaus*