### PR TITLE
MusicXML: export hidden features with print-object="no"

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -2199,7 +2199,7 @@ void ExportMusicXml::timesig(const TimeSig* tsig, staff_idx_t staff)
         attrs.push_back({ "number", staff });
     }
 
-    if (!tsig->visible() || !tsig->showOnThisStaff()) {
+    if (!tsig->visible() || !tsig->showOnThisStaff() || (tsig->staff() && !tsig->staff()->staffType(tsig->tick())->genTimesig())) {
         attrs.emplace_back(std::make_pair("print-object", "no"));
     }
 
@@ -2438,7 +2438,7 @@ void ExportMusicXml::keysig(const KeySig* ks, ClefType ct, staff_idx_t staff, bo
     if (staff) {
         attrs.emplace_back(std::make_pair("number", staff));
     }
-    if (!visible) {
+    if (!visible || (ks->staff() && !ks->staff()->staffType(ks->tick())->genKeysig())) {
         attrs.emplace_back(std::make_pair("print-object", "no"));
     }
     addColorAttr(ks, attrs);
@@ -4576,7 +4576,7 @@ void ExportMusicXml::rest(Rest* rest, staff_idx_t staff, const std::vector<Lyric
     String noteTag = u"note";
     noteTag += color2xml(rest);
     noteTag += elementPosition(this, rest);
-    if (!rest->visible()) {
+    if (!rest->visible() || (rest->staff() && !rest->staff()->staffType(rest->tick())->showRests())) {
         noteTag += u" print-object=\"no\"";
     }
     m_xml.startElementRaw(noteTag);
@@ -7578,7 +7578,7 @@ void ExportMusicXml::findAndExportClef(const Measure* const m, const int staves,
                     && ((seg->measure() != m) || ((seg->segmentType() == SegmentType::HeaderClef) && !cle->otherClef()))) {
                     clefDebug("exportxml: clef exported");
                     String clefAttr = color2xml(cle);
-                    if (!cle->visible()) {
+                    if (!cle->visible() || (cle->staff() && !cle->staff()->staffType(cle->tick())->genClef())) {
                         clefAttr += u" print-object=\"no\"";
                     }
                     clef(sstaff, cle->clefType(), clefAttr);
@@ -7841,7 +7841,7 @@ void ExportMusicXml::writeElement(EngravingItem* el, const Measure* m, staff_idx
         // these will be output at the start of the next measure
         const Clef* cle = toClef(el);
         const Fraction ti = cle->segment()->tick();
-        const String visible = (!cle->visible()) ? u" print-object=\"no\"" : String();
+        const String visible = (!cle->visible() || (cle->staff() && !cle->staff()->staffType(cle->tick())->genClef())) ? u" print-object=\"no\"" : String();
         clefDebug("exportxml: clef in measure ti=%d ct=%d gen=%d", ti, int(cle->clefType()), el->generated());
         if (el->generated()) {
             clefDebug("exportxml: generated clef not exported");

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -7845,8 +7845,7 @@ void ExportMusicXml::writeElement(EngravingItem* el, const Measure* m, staff_idx
         // these will be output at the start of the next measure
         const Clef* cle = toClef(el);
         const Fraction ti = cle->segment()->tick();
-        const String visible
-            = (!cle->visible() || (cle->staff() && !cle->staff()->staffType(cle->tick())->genClef())) ? u" print-object=\"no\"" : String();
+        const String visible = (!cle->visible()) ? u" print-object=\"no\"" : String();
         clefDebug("exportxml: clef in measure ti=%d ct=%d gen=%d", ti, int(cle->clefType()), el->generated());
         if (el->generated()) {
             clefDebug("exportxml: generated clef not exported");

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -4579,7 +4579,8 @@ void ExportMusicXml::rest(Rest* rest, staff_idx_t staff, const std::vector<Lyric
     noteTag += color2xml(rest);
     noteTag += elementPosition(this, rest);
     if (!rest->visible()
-        || (rest->staff() && rest->staff()->staffType(rest->tick())->isTabStaff() && !rest->staff()->staffType(rest->tick())->showRests())) {
+        || (rest->staff() && rest->staff()->staffType(rest->tick())->isTabStaff()
+            && !rest->staff()->staffType(rest->tick())->showRests())) {
         noteTag += u" print-object=\"no\"";
     }
     m_xml.startElementRaw(noteTag);

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -4579,7 +4579,7 @@ void ExportMusicXml::rest(Rest* rest, staff_idx_t staff, const std::vector<Lyric
     noteTag += color2xml(rest);
     noteTag += elementPosition(this, rest);
     if (!rest->visible()
-        || (rest->staff() && !rest->staff()->staffType(rest->tick())->showRests())) {
+        || (rest->staff() && rest->staff()->staffType(rest->tick())->isTabStaff() && !rest->staff()->staffType(rest->tick())->showRests())) {
         noteTag += u" print-object=\"no\"";
     }
     m_xml.startElementRaw(noteTag);

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -2199,7 +2199,8 @@ void ExportMusicXml::timesig(const TimeSig* tsig, staff_idx_t staff)
         attrs.push_back({ "number", staff });
     }
 
-    if (!tsig->visible() || !tsig->showOnThisStaff() || (tsig->staff() && !tsig->staff()->staffType(tsig->tick())->genTimesig())) {
+    if (!tsig->visible() || !tsig->showOnThisStaff()
+        || (tsig->staff() && !tsig->staff()->staffType(tsig->tick())->genTimesig())) {
         attrs.emplace_back(std::make_pair("print-object", "no"));
     }
 
@@ -2438,7 +2439,8 @@ void ExportMusicXml::keysig(const KeySig* ks, ClefType ct, staff_idx_t staff, bo
     if (staff) {
         attrs.emplace_back(std::make_pair("number", staff));
     }
-    if (!visible || (ks->staff() && !ks->staff()->staffType(ks->tick())->genKeysig())) {
+    if (!visible
+        || (ks->staff() && !ks->staff()->staffType(ks->tick())->genKeysig())) {
         attrs.emplace_back(std::make_pair("print-object", "no"));
     }
     addColorAttr(ks, attrs);
@@ -4576,7 +4578,8 @@ void ExportMusicXml::rest(Rest* rest, staff_idx_t staff, const std::vector<Lyric
     String noteTag = u"note";
     noteTag += color2xml(rest);
     noteTag += elementPosition(this, rest);
-    if (!rest->visible() || (rest->staff() && !rest->staff()->staffType(rest->tick())->showRests())) {
+    if (!rest->visible()
+        || (rest->staff() && !rest->staff()->staffType(rest->tick())->showRests())) {
         noteTag += u" print-object=\"no\"";
     }
     m_xml.startElementRaw(noteTag);
@@ -7578,7 +7581,8 @@ void ExportMusicXml::findAndExportClef(const Measure* const m, const int staves,
                     && ((seg->measure() != m) || ((seg->segmentType() == SegmentType::HeaderClef) && !cle->otherClef()))) {
                     clefDebug("exportxml: clef exported");
                     String clefAttr = color2xml(cle);
-                    if (!cle->visible() || (cle->staff() && !cle->staff()->staffType(cle->tick())->genClef())) {
+                    if (!cle->visible()
+                        || (cle->staff() && !cle->staff()->staffType(cle->tick())->genClef())) {
                         clefAttr += u" print-object=\"no\"";
                     }
                     clef(sstaff, cle->clefType(), clefAttr);
@@ -7841,7 +7845,8 @@ void ExportMusicXml::writeElement(EngravingItem* el, const Measure* m, staff_idx
         // these will be output at the start of the next measure
         const Clef* cle = toClef(el);
         const Fraction ti = cle->segment()->tick();
-        const String visible = (!cle->visible() || (cle->staff() && !cle->staff()->staffType(cle->tick())->genClef())) ? u" print-object=\"no\"" : String();
+        const String visible
+            = (!cle->visible() || (cle->staff() && !cle->staff()->staffType(cle->tick())->genClef())) ? u" print-object=\"no\"" : String();
         clefDebug("exportxml: clef in measure ti=%d ct=%d gen=%d", ti, int(cle->clefType()), el->generated());
         if (el->generated()) {
             clefDebug("exportxml: generated clef not exported");

--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -7846,7 +7846,8 @@ void ExportMusicXml::writeElement(EngravingItem* el, const Measure* m, staff_idx
         // these will be output at the start of the next measure
         const Clef* cle = toClef(el);
         const Fraction ti = cle->segment()->tick();
-        const String visible = (!cle->visible()) ? u" print-object=\"no\"" : String();
+        const String visible
+            = (!cle->visible() || (cle->staff() && !cle->staff()->staffType(cle->tick())->genClef())) ? u" print-object=\"no\"" : String();
         clefDebug("exportxml: clef in measure ti=%d ct=%d gen=%d", ti, int(cle->clefType()), el->generated());
         if (el->generated()) {
             clefDebug("exportxml: generated clef not exported");

--- a/src/importexport/musicxml/tests/data/testDrumset1.xml
+++ b/src/importexport/musicxml/tests/data/testDrumset1.xml
@@ -108,10 +108,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testDrumset2.xml
+++ b/src/importexport/musicxml/tests/data/testDrumset2.xml
@@ -98,10 +98,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -165,10 +165,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -236,10 +236,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testGuitarBends_ref.xml
+++ b/src/importexport/musicxml/tests/data/testGuitarBends_ref.xml
@@ -36,10 +36,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -356,7 +356,7 @@
             </technical>
           </notations>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>1</voice>

--- a/src/importexport/musicxml/tests/data/testHammerPull.xml
+++ b/src/importexport/musicxml/tests/data/testHammerPull.xml
@@ -36,10 +36,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testHarmony7_ref.xml
+++ b/src/importexport/musicxml/tests/data/testHarmony7_ref.xml
@@ -36,10 +36,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -472,7 +472,7 @@
             </frame-note>
           </frame>
         </harmony>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>4</duration>
         <voice>1</voice>
@@ -482,7 +482,7 @@
       <backup>
         <duration>4</duration>
         </backup>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>4</duration>
         <voice>5</voice>
@@ -543,14 +543,14 @@
         <stem>up</stem>
         <staff>1</staff>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>1</voice>
@@ -642,14 +642,14 @@
         <stem>down</stem>
         <staff>1</staff>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>2</voice>
@@ -693,14 +693,14 @@
             </technical>
           </notations>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>5</voice>
@@ -744,14 +744,14 @@
             </technical>
           </notations>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>6</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>1</duration>
         <voice>6</voice>

--- a/src/importexport/musicxml/tests/data/testImportDrums.xml
+++ b/src/importexport/musicxml/tests/data/testImportDrums.xml
@@ -171,7 +171,7 @@
     </measure>
     <measure number="3">
       <attributes/>
-      <note print-object="no">
+      <note>
         <rest/>
         <duration>256</duration>
         <voice>1</voice>
@@ -180,7 +180,7 @@
     </measure>
     <measure number="4">
       <attributes/>
-      <note print-object="no">
+      <note>
         <rest/>
         <duration>256</duration>
         <voice>1</voice>

--- a/src/importexport/musicxml/tests/data/testImportDrums.xml
+++ b/src/importexport/musicxml/tests/data/testImportDrums.xml
@@ -171,7 +171,7 @@
     </measure>
     <measure number="3">
       <attributes/>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>256</duration>
         <voice>1</voice>
@@ -180,7 +180,7 @@
     </measure>
     <measure number="4">
       <attributes/>
-      <note>
+      <note print-object="no">
         <rest/>
         <duration>256</duration>
         <voice>1</voice>

--- a/src/importexport/musicxml/tests/data/testInstrImport.xml
+++ b/src/importexport/musicxml/tests/data/testInstrImport.xml
@@ -260,7 +260,7 @@
   <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -287,7 +287,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -314,7 +314,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -341,7 +341,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -368,7 +368,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -395,7 +395,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -422,7 +422,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -449,7 +449,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -476,7 +476,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -503,7 +503,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -530,7 +530,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -557,7 +557,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -584,7 +584,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -611,7 +611,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -638,7 +638,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -665,7 +665,7 @@
     <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
@@ -714,7 +714,7 @@
       <measure number="1">
       <attributes>
         <divisions>64</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>major</mode>
         </key>

--- a/src/importexport/musicxml/tests/data/testMS3KitAndPerc.xml
+++ b/src/importexport/musicxml/tests/data/testMS3KitAndPerc.xml
@@ -537,10 +537,10 @@
         </print>
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -2104,10 +2104,10 @@
         </print>
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testMidiPortExport_ref.xml
+++ b/src/importexport/musicxml/tests/data/testMidiPortExport_ref.xml
@@ -4352,7 +4352,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4373,7 +4373,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4394,7 +4394,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4415,7 +4415,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4436,7 +4436,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4457,7 +4457,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4478,7 +4478,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4499,7 +4499,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4520,7 +4520,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4541,7 +4541,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4562,7 +4562,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4583,7 +4583,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4604,7 +4604,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4625,7 +4625,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4646,7 +4646,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4667,7 +4667,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>
@@ -4688,7 +4688,7 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
         <clef>

--- a/src/importexport/musicxml/tests/data/testNegativeOctave_ref.xml
+++ b/src/importexport/musicxml/tests/data/testNegativeOctave_ref.xml
@@ -36,10 +36,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testSticking.xml
+++ b/src/importexport/musicxml/tests/data/testSticking.xml
@@ -451,7 +451,7 @@
         <beam number="1">end</beam>
         <beam number="2">end</beam>
         </note>
-      <note print-object="no">
+      <note default-x="292.7" default-y="-20">
         <rest/>
         <duration>8</duration>
         <voice>1</voice>
@@ -577,7 +577,7 @@
             </articulations>
           </notations>
         </note>
-      <note print-object="no">
+      <note default-x="199.79" default-y="-20">
         <rest/>
         <duration>8</duration>
         <voice>1</voice>
@@ -678,13 +678,13 @@
             </articulations>
           </notations>
         </note>
-      <note print-object="no">
+      <note default-x="125.44" default-y="-20">
         <rest/>
         <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note print-object="no">
+      <note default-x="188.44" default-y="-20">
         <rest/>
         <duration>8</duration>
         <voice>1</voice>

--- a/src/importexport/musicxml/tests/data/testSticking.xml
+++ b/src/importexport/musicxml/tests/data/testSticking.xml
@@ -295,11 +295,11 @@
         </print>
       <attributes>
         <divisions>4</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           <mode>none</mode>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -451,7 +451,7 @@
         <beam number="1">end</beam>
         <beam number="2">end</beam>
         </note>
-      <note default-x="292.7" default-y="-20">
+      <note print-object="no">
         <rest/>
         <duration>8</duration>
         <voice>1</voice>
@@ -577,7 +577,7 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="199.79" default-y="-20">
+      <note print-object="no">
         <rest/>
         <duration>8</duration>
         <voice>1</voice>
@@ -678,13 +678,13 @@
             </articulations>
           </notations>
         </note>
-      <note default-x="125.44" default-y="-20">
+      <note print-object="no">
         <rest/>
         <duration>4</duration>
         <voice>1</voice>
         <type>quarter</type>
         </note>
-      <note default-x="188.44" default-y="-20">
+      <note print-object="no">
         <rest/>
         <duration>8</duration>
         <voice>1</voice>

--- a/src/importexport/musicxml/tests/data/testStringData.xml
+++ b/src/importexport/musicxml/tests/data/testStringData.xml
@@ -36,10 +36,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testSystemBrackets3.xml
+++ b/src/importexport/musicxml/tests/data/testSystemBrackets3.xml
@@ -125,10 +125,10 @@ Gtr.</part-abbreviation>
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -151,10 +151,10 @@ Gtr.</part-abbreviation>
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -219,10 +219,10 @@ Gtr.</part-abbreviation>
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -287,10 +287,10 @@ Gtr.</part-abbreviation>
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -355,10 +355,10 @@ Gtr.</part-abbreviation>
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testTablature1.xml
+++ b/src/importexport/musicxml/tests/data/testTablature1.xml
@@ -37,10 +37,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>3</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testTablature2.xml
+++ b/src/importexport/musicxml/tests/data/testTablature2.xml
@@ -37,10 +37,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>3</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testTablature3.xml
+++ b/src/importexport/musicxml/tests/data/testTablature3.xml
@@ -37,10 +37,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testTablature4.xml
+++ b/src/importexport/musicxml/tests/data/testTablature4.xml
@@ -51,10 +51,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -135,10 +135,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testTablature5.xml
+++ b/src/importexport/musicxml/tests/data/testTablature5.xml
@@ -37,10 +37,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testTablature5_ref.xml
+++ b/src/importexport/musicxml/tests/data/testTablature5_ref.xml
@@ -37,10 +37,10 @@
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testTapping.xml
+++ b/src/importexport/musicxml/tests/data/testTapping.xml
@@ -36,10 +36,10 @@
     <measure number="1">
       <attributes>
         <divisions>2</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testVirtualInstruments.xml
+++ b/src/importexport/musicxml/tests/data/testVirtualInstruments.xml
@@ -62,10 +62,10 @@
     <measure number="1">
       <attributes>
         <divisions>2</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -128,10 +128,10 @@
     <measure number="1">
       <attributes>
         <divisions>2</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -194,10 +194,10 @@
     <measure number="1">
       <attributes>
         <divisions>2</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>

--- a/src/importexport/musicxml/tests/data/testVirtualInstruments_ref.xml
+++ b/src/importexport/musicxml/tests/data/testVirtualInstruments_ref.xml
@@ -325,10 +325,10 @@
     <measure number="1">
       <attributes>
         <divisions>2</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -387,10 +387,10 @@
     <measure number="1">
       <attributes>
         <divisions>2</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>
@@ -449,10 +449,10 @@
     <measure number="1">
       <attributes>
         <divisions>2</divisions>
-        <key>
+        <key print-object="no">
           <fifths>0</fifths>
           </key>
-        <time>
+        <time print-object="no">
           <beats>4</beats>
           <beat-type>4</beat-type>
           </time>


### PR DESCRIPTION
Modified the MusicXML exporter to respect staff-specific visibility settings for time signatures, key signatures, clefs, and rests. When these elements are suppressed by the staff style (e.g., hidden time signatures on tablature staves), they are now exported with the `print-object="no"` attribute.

Specifically updated:
- `ExportMusicXml::timesig` to check `StaffType::genTimesig()`
- `ExportMusicXml::keysig` to check `StaffType::genKeysig()`
- `ExportMusicXml::rest` to check `StaffType::showRests()`
- `ExportMusicXml::findAndExportClef` and `ExportMusicXml::writeElement` to check `StaffType::genClef()`

---
*PR created automatically by Jules for task [4264131253572754432](https://jules.google.com/task/4264131253572754432) started by @rettinghaus*