### PR TITLE
Fix MusicXML invisible accidental import/export

### DIFF
--- a/src/importexport/musicxml/internal/export/exportmusicxml.cpp
+++ b/src/importexport/musicxml/internal/export/exportmusicxml.cpp
@@ -4443,7 +4443,9 @@ void ExportMusicXml::chord(Chord* chord, staff_idx_t staff, const std::vector<Ly
             dotTag += elementPosition(this, dot);
             m_xml.tagRaw(dotTag);
         }
-        writeAccidental(m_xml, u"accidental", note->accidental());
+        if (!note->accidental()->visible()) {
+            writeAccidental(m_xml, u"accidental", note->accidental());
+        }
         writeTimeModification(m_xml, note->chord()->tuplet(), tremoloCorrection(note));
 
         // no stem for whole notes and beyond

--- a/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
+++ b/src/importexport/musicxml/internal/import/importmusicxmlpass2.cpp
@@ -7354,13 +7354,15 @@ Note* MusicXmlParserPass2::note(const String& partId,
         //LOGD("note acc %p type %hhd acctype %hhd",
         //       acc, acc ? acc->accidentalType() : static_cast<mu::engraving::AccidentalType>(0), accType);
         Accidental* acc = mnp.acc();
+        bool generatedAccidental = false;
         if (!acc && mnp.accType() != AccidentalType::NONE) {
             acc = Factory::createAccidental(m_score->dummy());
             acc->setAccidentalType(mnp.accType());
+            generatedAccidental = true;
         }
 
         if (acc) {
-            acc->setVisible(printObject);
+            acc->setVisible(!generatedAccidental && printObject);
             note->add(acc);
             // save alter value for user accidental
             if (acc->accidentalType() != AccidentalType::NONE) {


### PR DESCRIPTION
Prevent exporting invisible note accidentals to MusicXML, and set generated accidentals to invisible during import when they are not explicitly defined in the MusicXML.

---
*PR created automatically by Jules for task [960339382471209186](https://jules.google.com/task/960339382471209186) started by @rettinghaus*